### PR TITLE
Handle bad messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class LogstashUDP extends Transport {
     // prepare default meta object
     this.meta_defaults = Object.assign(options.meta || {}, {
       host: os.hostname(),
-      application: options.appName || process.title
+      application: options.appName || process.title,
     });
 
     // we want to avoid copy-by-reference for meta defaults, so make sure it's a flat object.
@@ -169,7 +169,7 @@ class LogstashUDP extends Transport {
     try {
       const logMessage = this._buildLog(info);
 
-      this.sender.send(logMessage, err => {
+      this.sender.send(logMessage, (err) => {
         if (err) {
           debug("received error while sending log", err);
           this.emit("warn", err);
@@ -180,6 +180,7 @@ class LogstashUDP extends Transport {
       });
     } catch (error) {
       debug("failed sending log", error);
+      callback(error, null);
     }
   }
 
@@ -191,7 +192,7 @@ class LogstashUDP extends Transport {
       "@version": "1",
       "@timestamp": new Date().toISOString(),
       level: info[LEVEL],
-      message: info.message
+      message: info.message,
     };
 
     return JSON.stringify(data);

--- a/test/winston-logstash-udp_test.js
+++ b/test/winston-logstash-udp_test.js
@@ -18,7 +18,7 @@ chai.use(sinonChai);
 
 require("../");
 
-describe("winston-logstash-udp transport", function() {
+describe("winston-logstash-udp transport", function () {
   var test_server,
     port = 9999,
     transport = null;
@@ -31,7 +31,7 @@ describe("winston-logstash-udp transport", function() {
     var server = dgram.createSocket("udp4");
     server.unref();
 
-    server.on("error", function(err) {
+    server.on("error", function (err) {
       console.log("server error:\n" + err.stack);
       server.close();
     });
@@ -52,7 +52,7 @@ describe("winston-logstash-udp transport", function() {
         port: port,
         appName: "test",
         localhost: "localhost",
-        pid: 12345
+        pid: 12345,
       },
       options = options || {},
       field;
@@ -70,11 +70,11 @@ describe("winston-logstash-udp transport", function() {
 
     return {
       logger: winston.createLogger({ transports: [transport] }),
-      transport
+      transport,
     };
   }
 
-  describe("with logstash server", function() {
+  describe("with logstash server", function () {
     beforeEach(() => timekeeper.freeze(freezed_time));
 
     it("handles non-objects in splat", async () => {
@@ -84,11 +84,11 @@ describe("winston-logstash-udp transport", function() {
         application: "test",
         host: os.hostname(),
         level: "info",
-        message: "hello world"
+        message: "hello world",
       };
 
-      const logSent = new Promise(resolve => {
-        test_server = createTestServer(port, function(data) {
+      const logSent = new Promise((resolve) => {
+        test_server = createTestServer(port, function (data) {
           resolve(data);
         });
       });
@@ -107,11 +107,11 @@ describe("winston-logstash-udp transport", function() {
         application: "test",
         host: os.hostname(),
         level: "info",
-        message: "hello world"
+        message: "hello world",
       };
 
-      const logSent = new Promise(resolve => {
-        test_server = createTestServer(port, function(data) {
+      const logSent = new Promise((resolve) => {
+        test_server = createTestServer(port, function (data) {
           resolve(data);
         });
       });
@@ -124,6 +124,14 @@ describe("winston-logstash-udp transport", function() {
       expect(response).to.be.eql(expected);
     });
 
+    it("handles bad formatted logs", async () => {
+      var logger = createLogger(port);
+
+      expect(() => {
+        logger.info("bad", { timer: setTimeout(() => {}, 10) });
+      }).to.throw(/Converting circular structure to JSON/);
+    });
+
     it("send logs with splat over UDP as valid json", async () => {
       var logger = createLogger(port);
       var expected = {
@@ -132,11 +140,11 @@ describe("winston-logstash-udp transport", function() {
         host: os.hostname(),
         level: "info",
         message: "hello world",
-        stream: "sample"
+        stream: "sample",
       };
 
-      const logSent = new Promise(resolve => {
-        test_server = createTestServer(port, function(data) {
+      const logSent = new Promise((resolve) => {
+        test_server = createTestServer(port, function (data) {
           resolve(data);
         });
       });
@@ -154,8 +162,8 @@ describe("winston-logstash-udp transport", function() {
 
       sinon.stub(transport, "_buildLog").returns('{"what":"ever"}');
 
-      const logSent = new Promise(resolve => {
-        test_server = createTestServer(port, function(data) {
+      const logSent = new Promise((resolve) => {
+        test_server = createTestServer(port, function (data) {
           resolve(data);
         });
       });
@@ -177,10 +185,10 @@ describe("winston-logstash-udp transport", function() {
     });
   });
 
-  describe("without logstash server", function() {
+  describe("without logstash server", function () {
     it("return an error message if UDP DNS errors occur on the socket", async () => {
       const { logger, transport } = createLoggerWithTransport(port, {
-        host: "unresolvedhost"
+        host: "unresolvedhost",
       });
 
       const warning = pEvent(transport, "warn");


### PR DESCRIPTION
Until now a single message that fails on `JSON.stringify` will block the whole transport, and will cause all future log requests to be buffered in memory